### PR TITLE
Add pre build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ This API server enables audio transcription using the OpenAI Whisper models.
 Before build make sure that **CGO_ENABLED** env is set to **1**
 
 ```
-set CGO_ENABLED 1
+$env:CGO_ENABLED = "1"
 ```
 
-or preferable set it parament. Then check it via
+you can check this with this command
 
 ```
 go env

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ This API server enables audio transcription using the OpenAI Whisper models.
 
 # Build from source
 
+Before build make sure that **CGO_ENABLED** env is set to **1**
+
+```
+set CGO_ENABLED 1
+```
+
+or preferable set it parament. Then check it via
+
+```
+go env
+```
+
+Also you have to have installed gcc x64 i.e. by MYSYS
+
 Download the sources and use `go build`.
 For example, you can build using the following command:
 


### PR DESCRIPTION
I really like this app but I had a lot of headache why it is not able to get build. Normally I work with NodeJS env and don't know much about go env.  When I was trying to build I got build errors but those didn't make sense and were not any helpfull to aim real problem which was this env variable not set to 1. That variable by defualt is 0 when installing Go on windows